### PR TITLE
Update setae api app for RTR and Eureka

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,6 @@
 name: PushImage
 
-on:
-  push:
-    branches: ['main']
+on: push
 
 permissions:
   contents: read
@@ -12,6 +10,9 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     steps:
+    - name: Extract branch name
+      id: extract_branch
+      run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx
       id: buildx
@@ -28,5 +29,5 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ghcr.io/sul-dlss/folio-setae-api:main
+        tags: ghcr.io/sul-dlss/folio-setae-api:${{ steps.extract_branch.outputs.branch }}
         file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python
 
 COPY ./pyproject.toml /app/
 
-RUN poetry install --no-dev
+RUN poetry install --without dev
 
 COPY ./app /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
+# FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11-2024-11-18
 
 # Install Poetry
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python && \

--- a/app/main.py
+++ b/app/main.py
@@ -213,7 +213,7 @@ def _okapi_login():
     r = requests.post(url, json=data, headers=headers)
     r.raise_for_status()
     if r.status_code == 201:
-        return r.headers["X-Okapi-Token"]
+        return r.json()["okapiToken"]
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "setae-api"
 version = "0.3.0"
 description = "API middleware for FOLIO"
 authors = ["Nick Cappadona <cappadona@users.noreply.github.com>"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
This is a bandaid for keeping the setae-api working with RTR and Eureka. This should work for prod when the main branch image gets updated, but we need to come up with a better way to manage the FastAPI dependencies so the pyproject is not pinning all of the dependencies to old versions. One way to do this is to redo the dockerfile so that it does not use a "fastapi  image" but rather uses a python base image, installs the dependencies using poetry and starts the FastAPI service (see https://fastapi.tiangolo.com/deployment/docker/#create-the-fastapi-code). 